### PR TITLE
fix(FEC-8091): remove does not work sometimes

### DIFF
--- a/src/shaka-offline-provider.js
+++ b/src/shaka-offline-provider.js
@@ -194,7 +194,6 @@ export class ShakaOfflineProvider extends FakeEventTarget {
     }).catch(error => {
       Promise.reject(error);
     });
-
   }
 
   _updateDrmDataIfNeeded(entryId, newMediaInfo) {


### PR DESCRIPTION
remove on the shaka provider + beautify
When removing, a download item (this._downloads[entryID]) must have a storage property.
In some usecases, the storage property was not added to the object (in setSessionData) so i added it there.