### PR TITLE
fix(FEC-8424): making the log message more clear

### DIFF
--- a/src/offline-manager.js
+++ b/src/offline-manager.js
@@ -112,7 +112,7 @@ export default class OfflineManager extends FakeEventTarget {
           return this._offlineProvider.pause(entryId).then(() => {
             currentDownload.state = downloadStates.PAUSED;
             return this._dbManager.update(ENTRIES_MAP_STORE_NAME, entryId, this._offlineProvider.prepareItemForStorage(currentDownload)).then(() => {
-              OfflineManager._logger.debug('paused ended', entryId);
+              OfflineManager._logger.debug(entryId, " download state: ", currentDownload.state);
               resolve({
                 entryId: entryId,
                 state: downloadStates.PAUSE
@@ -143,7 +143,7 @@ export default class OfflineManager extends FakeEventTarget {
         return this._offlineProvider.resume(entryId).then((manifestDB) => {
           currentDownload.state = [manifestDB.downloadStatus, manifestDB.ob].includes(downloadStates.ENDED) ? downloadStates.ENDED : downloadStates.PAUSED;
           this._dbManager.update(ENTRIES_MAP_STORE_NAME, entryId, this._offlineProvider.prepareItemForStorage(currentDownload)).then(() => {
-            OfflineManager._logger.debug('resume ended / paused', entryId);
+            OfflineManager._logger.debug(entryId, " download state: ", currentDownload.state);
             return Promise.resolve({
               state: currentDownload.state,
               entryId: entryId
@@ -208,7 +208,7 @@ export default class OfflineManager extends FakeEventTarget {
         this._offlineProvider.download(entryId, options)
           .then(this._dbManager.update(ENTRIES_MAP_STORE_NAME, entryId, this._offlineProvider.prepareItemForStorage(currentDownload)))
           .then(() => {
-            OfflineManager._logger.debug('download ended / paused', entryId);
+            OfflineManager._logger.debug(entryId, " download state: ", currentDownload.state);
             resolve({
               state: currentDownload.state,
               entryId: entryId


### PR DESCRIPTION
making the log message more clear.

instead of "download ended/paused"
entryID + "download state" + status.